### PR TITLE
Remove "Install it" from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ This software is under development
 
 - Download the latest build from: https://github.com/Codeusa/SteamCleaner/releases/latest
 
-- Install it
-
 - Run it
 
 


### PR DESCRIPTION
You're not installing anything with this program. 

All users are doing is downloading it (step 1) and then running it (step 3).