### PR TITLE
Battlenet cleanup

### DIFF
--- a/SteamCleaner/Analyzer/Analyzers/BattlenetAnalyzer.cs
+++ b/SteamCleaner/Analyzer/Analyzers/BattlenetAnalyzer.cs
@@ -24,26 +24,16 @@ namespace SteamCleaner.Analyzer.Analyzers
             if (File.Exists(productPath))
             {
                 var data = File.ReadAllText(productPath);
-                var rgx = new Regex(@"[^\u0020-\u007E]");
-                data = rgx.Replace(data, Environment.NewLine);
-                using (var reader = new StringReader(data))
+                foreach (Match match in Regex.Matches(data, @"(\u0021|\u001F)(.:/.*?)(\u0012\u0002)"))
                 {
-                    string line;
-                    while ((line = reader.ReadLine()) != null)
+                    if (match.Groups.Count != 4)
                     {
-                        line = line.Trim();
-                        line = line.Trim().Replace("!", "");
-                        line = line.Trim().Replace("!", "\"");
-                        if (string.IsNullOrEmpty(line) || string.IsNullOrWhiteSpace(line) || !line.Contains("/"))
-                            continue;
-                        if (line.StartsWith("\""))
-                        {
-                            line = line.Remove(0, 1);
-                        }
-                        if (Directory.Exists(line))
-                        {
-                            paths.Add(line);
-                        }
+                        continue;
+                    }
+                    var value = match.Groups[2].Value;
+                    if (Directory.Exists(value))
+                    {
+                        paths.Add(value);
                     }
                 }
             }
@@ -53,7 +43,7 @@ namespace SteamCleaner.Analyzer.Analyzers
         private string GetProductDbPath()
         {
             return Path.Combine(GetBattleNetPath(),
-                                "\\Agent\\product.db");
+                                "Agent\\product.db");
         }
 
         private string GetBattleNetPath()


### PR DESCRIPTION
Looking at the old code it looks like it just looked for paths that start with \u0021 or \u001F then trimmed that first character and used that as the directory. I replaced this with just one regex that should work.

I tested this against my product.db and it was able to read the same paths as the last one. I just don't have any cached files or something because there's only the C:/ProgramData/Battle.net/Agent and C:/Program Files (x86)/Battle.net paths.
