### PR TITLE
Only add primary steam directory if it exists. Fixes #27

### DIFF
--- a/SteamCleaner/Analyzer/Analyzers/SteamAnalyzer.cs
+++ b/SteamCleaner/Analyzer/Analyzers/SteamAnalyzer.cs
@@ -29,7 +29,12 @@ namespace SteamCleaner.Analyzer.Analyzers
                 return null;
             }
             var paths = new List<string>();
-            paths.Add(FixPath(steamPath));
+            var primarySteamPath = FixPath(steamPath);
+            // Program install directory may not exist in Steam install location. See issue #27
+            if (Directory.Exists(primarySteamPath))
+            {
+                paths.Add(primarySteamPath);
+            }
             var secondaryPaths = FindSecondaryInstallPaths(steamPath);
             if (secondaryPaths != null)
             {


### PR DESCRIPTION
Checks to ensure directory exists before adding it for analyzer.
Prevents error that doesn't process folders that do exist.
Fixes #27