### PR TITLE
Fix Directory not found exception

### DIFF
--- a/SteamCleaner/Analyzer/AnalyzerService.cs
+++ b/SteamCleaner/Analyzer/AnalyzerService.cs
@@ -121,7 +121,7 @@ namespace SteamCleaner.Analyzer
         private void CheckNesting(List<string> paths)
         {
             //Check if this still works!
-            var nested = paths.Select(Directory.GetDirectories)
+            var nested = paths.Where(Directory.Exists).Select(Directory.GetDirectories)
                 .SelectMany(nestedGameFolders => nestedGameFolders)
                 .ToList();
             paths.AddRange(nested);


### PR DESCRIPTION
Fix application crash due to an System.IO.DirectoryNotFoundException

On startup, Application crash due to an invalid path (C:\Program Files (x86)\Desura\Common\deepblack)
the game where removed manually not uninstalled, therefore the registry key where conserved.
and the Application found this invalid path